### PR TITLE
fix: circular json stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "circular-json": "^0.5.4",
     "debug": "3.1.0",
+    "safe-json-stringify": "^1.2.0",
     "yargs": "12.0.1"
   },
   "repository": {
@@ -70,6 +71,7 @@
     "@types/mocha": "^5.2.1",
     "@types/node": "^10.1.3",
     "@types/yargs": "^11.0.0",
+    "@types/safe-json-stringify": "^1.0.1",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "Hennadii Bulakh"
   ],
   "dependencies": {
-    "circular-json": "^0.5.4",
     "debug": "3.1.0",
     "safe-json-stringify": "^1.2.0",
     "yargs": "12.0.1"
@@ -66,7 +65,6 @@
     "mocha": "3.0.0 - 5.x.x"
   },
   "devDependencies": {
-    "@types/circular-json": "^0.4.0",
     "@types/debug": "0.0.30",
     "@types/mocha": "^5.2.1",
     "@types/node": "^10.1.3",

--- a/src/main/mocha.ts
+++ b/src/main/mocha.ts
@@ -1,5 +1,4 @@
 import { fork } from 'child_process';
-import * as CircularJSON from 'circular-json';
 import * as debug from 'debug';
 import * as Mocha from 'mocha';
 import { resolve as pathResolve } from 'path';
@@ -144,7 +143,7 @@ export default class MochaWrapper extends Mocha {
   private addSubprocessSuites(testArtifacts: ISubprocessResult): void {
     const rootSuite = this.suite;
     const serialized = testArtifacts.syncedSubprocessData!;
-    const { rootSuite: testRootSuite } = CircularJSON.parse(serialized.results, subprocessParseReviver);
+    const { rootSuite: testRootSuite } = JSON.parse(serialized.results, subprocessParseReviver);
 
     Object.assign(testRootSuite, {
       parent: rootSuite,
@@ -156,7 +155,7 @@ export default class MochaWrapper extends Mocha {
 
   private extractSubprocessRetriedTests(testArtifacts: ISubprocessResult): IRetriedTest[] {
     const serialized = testArtifacts.syncedSubprocessData!;
-    const { retriesTests } = CircularJSON.parse(serialized.retries, subprocessParseReviver);
+    const { retriesTests } = JSON.parse(serialized.retries, subprocessParseReviver);
 
     return retriesTests as IRetriedTest[];
   }

--- a/src/subprocess/runner.ts
+++ b/src/subprocess/runner.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import * as CircularJSON from 'circular-json';
+import * as stringify from 'safe-json-stringify';
 import * as Mocha from 'mocha';
 import { IRunner, reporters } from 'mocha';
 import * as yargs from 'yargs';
@@ -219,9 +219,9 @@ class Reporter extends reporters.Base {
     ipc.sendEnsureDelivered({
       data: {
         // can't use the root suite because it will not get revived in the master process
-        // @see https://github.com/WebReflection/circular-json/issues/44
-        results: CircularJSON.stringify({ rootSuite: this.rootSuite }),
-        retries: CircularJSON.stringify({ retriesTests }),
+        // @see https://github.com/debitoor/safe-json-stringify
+        results: stringify({ rootSuite: this.rootSuite }),
+        retries: stringify({ retriesTests }),
       },
       event: 'sync',
     });

--- a/src/subprocess/runner.ts
+++ b/src/subprocess/runner.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
-import * as stringify from 'safe-json-stringify';
 import * as Mocha from 'mocha';
 import { IRunner, reporters } from 'mocha';
+import * as stringify from 'safe-json-stringify';
 import * as yargs from 'yargs';
 
 import {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18617837/55707463-3d8de300-5a16-11e9-9e08-64c5850de4f3.png)

when i use the npm package `circular-json`, it throws an error `RangeError: Maximum call stack size exceeded`. 

when i use the npm package `safe-json-stringify`, the problem fixed.