### PR TITLE
Fix not showing actual/expected

### DIFF
--- a/src/main/runner.ts
+++ b/src/main/runner.ts
@@ -167,7 +167,7 @@ export default class RunnerMain extends Runner {
           this.emit('waiting', this.rootSuite);
           continue;
         }
-        
+
         if (!isEventWithId(data)) {
           continue;
         }
@@ -210,7 +210,12 @@ export default class RunnerMain extends Runner {
               throw new Error('Unexpected fail event without err field');
             }
 
-            this.emit(event, test, data.err);
+            if ('err' in test) {
+              this.emit(event, test, Object.assign({}, test.err, data.err))
+            } else {
+              this.emit(event, test, data.err)
+            }
+
             break;
           }
 


### PR DESCRIPTION
This PR fixes issue https://github.com/mocha-parallel/mocha-parallel-tests/issues/215

data.err was missing actual/expected
![image](https://user-images.githubusercontent.com/3316019/52862215-c8084380-3145-11e9-9eea-f3d540958cf2.png)


where test.err wasn't
![image](https://user-images.githubusercontent.com/3316019/52862175-9abb9580-3145-11e9-871f-c99004413f1a.png)

Nested describes were tested as well.

When tests throw an exception (new Error(..)) then:
testErrors is empty:
```
{}
```
And data.err is not:
```
{ message: 'some error',
  name: 'Error',
  stack:
   'Error: some error\n    at Context.<anonymous> (test/parallel-order/tests/parallel2.js:9:14)' }
```

Then when tests assert some result using nodejs assert lib we get:

testErrors:
```
{ generatedMessage: true,
  name: 'AssertionError [ERR_ASSERTION]',
  code: 'ERR_ASSERTION',
  actual: 'false',
  expected: 'true',
  operator: '==' }
```

data.err
```
{ message:
   'The expression evaluated to a falsy value:\n\n  assert(false)\n',
  name: 'AssertionError [ERR_ASSERTION]',
  stack:
   'AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert(false)\n\n    at Context.<anonymous> (test/parallel-order/tests/parallel2.js:10:9)' }
```

And when using chai assertion lib:

testErrors
```
{ name: 'AssertionError',
  message: 'expected false to deeply equal true',
  showDiff: true,
  actual: 'false',
  expected: 'true',
  stack:
   'AssertionError: expected false to deeply equal true\n    at Context.<anonymous> (test/parallel-order/tests/parallel2.js:11:26)' }
```

data.err
```
{ message: 'expected false to deeply equal true',
  name: 'AssertionError',
  stack:
   'AssertionError: expected false to deeply equal true\n    at Context.<anonymous> (test/parallel-order/tests/parallel2.js:11:26)' }
```